### PR TITLE
fix: Fix JitPack build

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+install:
+  - ./gradlew :interconnect:publishToMavenLocal
+jdk:
+  - openjdk17


### PR DESCRIPTION
The changes adding a pro module and such made JitPack unhappy. This overrides the JitPack build command to only operate on the `interconnect` module instead of the entire project.