### PR TITLE
feat: Make domains selected through interconnect open in target without prompting

### DIFF
--- a/app/schemas/fe.linksheet.module.database.LinkSheetDatabase/11.json
+++ b/app/schemas/fe.linksheet.module.database.LinkSheetDatabase/11.json
@@ -1,0 +1,344 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "1a8953ff6e561da3ebb98fd67ad6d1c3",
+    "entities": [
+      {
+        "tableName": "openwith",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `host` TEXT NOT NULL, `packageName` TEXT, `component` TEXT NOT NULL, `alwaysPreferred` INTEGER NOT NULL, `setByInterconnect` INTEGER NOT NULL DEFAULT false)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "component",
+            "columnName": "component",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alwaysPreferred",
+            "columnName": "alwaysPreferred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setByInterconnect",
+            "columnName": "setByInterconnect",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_openwith_host",
+            "unique": true,
+            "columnNames": [
+              "host"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_openwith_host` ON `${TABLE_NAME}` (`host`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "app_selection_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `host` TEXT NOT NULL, `packageName` TEXT NOT NULL, `lastUsed` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsed",
+            "columnName": "lastUsed",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_app_selection_history_host_lastUsed",
+            "unique": true,
+            "columnNames": [
+              "host",
+              "lastUsed"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_app_selection_history_host_lastUsed` ON `${TABLE_NAME}` (`host`, `lastUsed`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "whitelisted_browser",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `packageName` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_whitelisted_browser_packageName",
+            "unique": true,
+            "columnNames": [
+              "packageName"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_whitelisted_browser_packageName` ON `${TABLE_NAME}` (`packageName`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "whitelisted_in_app_browser",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `packageName` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_whitelisted_in_app_browser_packageName",
+            "unique": true,
+            "columnNames": [
+              "packageName"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_whitelisted_in_app_browser_packageName` ON `${TABLE_NAME}` (`packageName`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "resolved_redirect",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`shortUrl` TEXT NOT NULL, `resolvedUrl` TEXT NOT NULL, PRIMARY KEY(`shortUrl`, `resolvedUrl`))",
+        "fields": [
+          {
+            "fieldPath": "shortUrl",
+            "columnName": "shortUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resolvedUrl",
+            "columnName": "resolvedUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "shortUrl",
+            "resolvedUrl"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "lib_redirect_default",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serviceKey` TEXT NOT NULL, `frontendKey` TEXT NOT NULL, `instanceUrl` TEXT NOT NULL, PRIMARY KEY(`serviceKey`))",
+        "fields": [
+          {
+            "fieldPath": "serviceKey",
+            "columnName": "serviceKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "frontendKey",
+            "columnName": "frontendKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceUrl",
+            "columnName": "instanceUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serviceKey"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "lib_redirect_service_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serviceKey` TEXT NOT NULL, `enabled` INTEGER NOT NULL, PRIMARY KEY(`serviceKey`))",
+        "fields": [
+          {
+            "fieldPath": "serviceKey",
+            "columnName": "serviceKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serviceKey"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "disable_in_app_browser_in_selected",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `packageName` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_disable_in_app_browser_in_selected_packageName",
+            "unique": true,
+            "columnNames": [
+              "packageName"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_disable_in_app_browser_in_selected_packageName` ON `${TABLE_NAME}` (`packageName`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "amp2html_mapping",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`ampUrl` TEXT NOT NULL, `canonicalUrl` TEXT NOT NULL, PRIMARY KEY(`ampUrl`, `canonicalUrl`))",
+        "fields": [
+          {
+            "fieldPath": "ampUrl",
+            "columnName": "ampUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canonicalUrl",
+            "columnName": "canonicalUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "ampUrl",
+            "canonicalUrl"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1a8953ff6e561da3ebb98fd67ad6d1c3')"
+    ]
+  }
+}

--- a/app/src/main/java/fe/linksheet/activity/BottomSheetActivity.kt
+++ b/app/src/main/java/fe/linksheet/activity/BottomSheetActivity.kt
@@ -996,7 +996,8 @@ class BottomSheetActivity : ComponentActivity() {
         privateBrowsingBrowser: PrivateBrowsingBrowser? = null
     ) {
         val deferred = bottomSheetViewModel.launchAppAsync(
-            info, result.intent, always, privateBrowsingBrowser
+            info, result.intent, always, privateBrowsingBrowser,
+            result.setByInterconnect == true,
         )
 
         deferred.invokeOnCompletion {

--- a/app/src/main/java/fe/linksheet/module/database/DatabaseModule.kt
+++ b/app/src/main/java/fe/linksheet/module/database/DatabaseModule.kt
@@ -38,7 +38,7 @@ val databaseModule = module {
         WhitelistedInAppBrowser::class, ResolvedRedirect::class, LibRedirectDefault::class,
         LibRedirectServiceState::class, DisableInAppBrowserInSelected::class, Amp2HtmlMapping::class
     ],
-    version = 10,
+    version = 11,
     autoMigrations = [
         AutoMigration(from = 2, to = 3),
         AutoMigration(from = 3, to = 4),
@@ -47,7 +47,8 @@ val databaseModule = module {
         AutoMigration(from = 6, to = 7),
         AutoMigration(from = 7, to = 8),
         AutoMigration(from = 8, to = 9),
-        AutoMigration(from = 9, to = 10)
+        AutoMigration(from = 9, to = 10),
+        AutoMigration(from = 10, to = 11)
     ],
     exportSchema = true
 )

--- a/app/src/main/java/fe/linksheet/module/database/entity/PreferredApp.kt
+++ b/app/src/main/java/fe/linksheet/module/database/entity/PreferredApp.kt
@@ -27,7 +27,9 @@ data class PreferredApp(
     val host: String,
     val packageName: String? = null,
     val component: String,
-    val alwaysPreferred: Boolean
+    val alwaysPreferred: Boolean,
+    @ColumnInfo(defaultValue = "false")
+    val setByInterconnect: Boolean = false,
 ) : LogDumpable {
     @delegate:Ignore
     val componentName by lazy {

--- a/app/src/main/java/fe/linksheet/module/resolver/IntentResolver.kt
+++ b/app/src/main/java/fe/linksheet/module/resolver/IntentResolver.kt
@@ -315,6 +315,7 @@ class IntentResolver(
             filteredItem,
             showExtended,
             preferredApp?.app?.alwaysPreferred,
+            preferredApp?.app?.setByInterconnect,
             selectedBrowserIsSingleOption || noBrowsersPresentOnlySingleApp,
             resolved,
             libRedirectResult,

--- a/app/src/main/java/fe/linksheet/module/viewmodel/BottomSheetViewModel.kt
+++ b/app/src/main/java/fe/linksheet/module/viewmodel/BottomSheetViewModel.kt
@@ -98,7 +98,7 @@ class BottomSheetViewModel(
         })
     }
 
-    private suspend fun persistSelectedIntent(intent: Intent, always: Boolean) {
+    private suspend fun persistSelectedIntent(intent: Intent, always: Boolean, setByInterconnect: Boolean) {
         logger.debug("Component=${intent.component}")
 
         intent.component?.let { component ->
@@ -107,7 +107,8 @@ class BottomSheetViewModel(
                 host = host,
                 packageName = component.packageName,
                 component = component.flattenToString(),
-                alwaysPreferred = always
+                alwaysPreferred = always,
+                setByInterconnect = setByInterconnect,
             )
 
             logger.debug("Inserting=$app")
@@ -147,14 +148,15 @@ class BottomSheetViewModel(
         info: DisplayActivityInfo,
         intent: Intent,
         always: Boolean = false,
-        privateBrowsingBrowser: PrivateBrowsingBrowser? = null
+        privateBrowsingBrowser: PrivateBrowsingBrowser? = null,
+        setByInterconnect: Boolean = false,
     ) = ioAsync {
         val newIntent = info.intentFrom(intent).let {
             privateBrowsingBrowser?.requestPrivateBrowsing(it) ?: it
         }
 
         if (privateBrowsingBrowser == null) {
-            persistSelectedIntent(newIntent, always)
+            persistSelectedIntent(newIntent, always, setByInterconnect)
         }
 
         newIntent

--- a/app/src/main/java/fe/linksheet/resolver/BottomSheetSuccessResult.kt
+++ b/app/src/main/java/fe/linksheet/resolver/BottomSheetSuccessResult.kt
@@ -16,6 +16,7 @@ sealed class BottomSheetResult(val uri: Uri?) {
         val filteredItem: DisplayActivityInfo?,
         val showExtended: Boolean,
         private val alwaysPreferred: Boolean?,
+        val setByInterconnect: Boolean?,
         private val hasSingleMatchingOption: Boolean = false,
         val resolveResults: Map<IntentResolver.Resolved, Result<ResolveType>?>,
         val libRedirectResult: LibRedirectResolver.LibRedirectResult? = null,
@@ -24,7 +25,7 @@ sealed class BottomSheetResult(val uri: Uri?) {
         val totalCount = resolved.size + if (filteredItem != null) 1 else 0
         val isEmpty = totalCount == 0
 
-        val isRegularPreferredApp = alwaysPreferred == true && filteredItem != null
+        val isRegularPreferredApp = setByInterconnect == true || (alwaysPreferred == true && filteredItem != null)
 
         val hasAutoLaunchApp = isRegularPreferredApp || hasSingleMatchingOption
 

--- a/versions.properties
+++ b/versions.properties
@@ -47,4 +47,4 @@ version.junit.junit=4.13.2
 version.koin=3.4.3
 version.org.jsoup..jsoup=1.16.1
 version.org.lsposed.hiddenapibypass..hiddenapibypass=4.3
-version.com.github.1fexd..LinkSheetInterConnect=1.0.6
+version.com.github.1fexd..LinkSheetInterConnect=1.1.0


### PR DESCRIPTION
Adds a new field to `PreferredApp` called `setByInterconnect`. When true, the bottom sheet won't show an app picker, even if other apps match the Intent.