### PR TITLE
fix: Assume match with preferred app if there's only one resolved Intent

### DIFF
--- a/app/src/main/java/fe/linksheet/InterconnectService.kt
+++ b/app/src/main/java/fe/linksheet/InterconnectService.kt
@@ -12,13 +12,19 @@ import androidx.core.app.ServiceCompat
 import androidx.core.graphics.drawable.IconCompat
 import fe.linksheet.activity.SelectDomainsConfirmationActivity
 import fe.linksheet.interconnect.ILinkSheetService
+import fe.linksheet.interconnect.ISelectedDomainsCallback
 import fe.linksheet.interconnect.StringParceledListSlice
 import fe.linksheet.module.repository.PreferredAppRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.koin.android.ext.android.inject
 
-class InterconnectService : Service() {
-    private val repository: PreferredAppRepository by inject()
+class InterconnectService : Service(), CoroutineScope by MainScope() {
+    private val preferredAppRepository: PreferredAppRepository by inject()
 
     override fun onCreate() {
         val nm = NotificationManagerCompat.from(this)
@@ -44,8 +50,21 @@ class InterconnectService : Service() {
             override fun getSelectedDomains(packageName: String): StringParceledListSlice {
                 verifyCaller(packageName)
 
-                return runBlocking {
-                    StringParceledListSlice(repository.getByPackageName(packageName).map { it.host })
+                return runBlocking(Dispatchers.IO) {
+                    try {
+                        this@InterconnectService.getSelectedDomains(packageName)
+                    } catch (e: Exception) {
+                        cancel(e.message!!, e)
+                        throw e
+                    }
+                }
+            }
+
+            override fun getSelectedDomainsAsync(packageName: String, callback: ISelectedDomainsCallback) {
+                verifyCaller(packageName)
+
+                launch(Dispatchers.IO) {
+                    callback.onSelectedDomainsRetrieved(this@InterconnectService.getSelectedDomains(packageName))
                 }
             }
 
@@ -71,6 +90,7 @@ class InterconnectService : Service() {
 
     override fun onDestroy() {
         ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
+        cancel()
 
         super.onDestroy()
     }
@@ -80,5 +100,11 @@ class InterconnectService : Service() {
         if (callingPackages?.contains(passedPackage) != true) {
             throw IllegalAccessException("Calling package is not $passedPackage!")
         }
+    }
+
+    private suspend fun getSelectedDomains(packageName: String): StringParceledListSlice {
+        return StringParceledListSlice(
+            preferredAppRepository.getByPackageName(packageName).map { it.host }
+        )
     }
 }

--- a/app/src/main/java/fe/linksheet/activity/SelectDomainsConfirmationActivity.kt
+++ b/app/src/main/java/fe/linksheet/activity/SelectDomainsConfirmationActivity.kt
@@ -6,15 +6,23 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.core.content.IntentCompat
@@ -29,7 +37,9 @@ import fe.linksheet.composable.util.SubtitleText
 import fe.linksheet.extension.android.getApplicationInfoCompat
 import fe.linksheet.extension.android.initPadding
 import fe.linksheet.interconnect.StringParceledListSlice
+import fe.linksheet.module.database.entity.AppSelectionHistory
 import fe.linksheet.module.database.entity.PreferredApp
+import fe.linksheet.module.repository.AppSelectionHistoryRepository
 import fe.linksheet.module.repository.PreferredAppRepository
 import fe.linksheet.ui.AppTheme
 import kotlinx.coroutines.Dispatchers
@@ -62,7 +72,8 @@ class SelectDomainsConfirmationActivity : ComponentActivity() {
         }
     }
 
-    private val repository: PreferredAppRepository by inject()
+    private val preferredAppRepository: PreferredAppRepository by inject()
+    private val appSelectionHistoryRepository: AppSelectionHistoryRepository by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -94,24 +105,53 @@ class SelectDomainsConfirmationActivity : ComponentActivity() {
         setContent {
             val scope = rememberCoroutineScope()
 
+            var loading by remember {
+                mutableStateOf(false)
+            }
+
             AppTheme {
                 Box(
                     modifier = Modifier
-                        .fillMaxWidth()
+                        .fillMaxSize(),
+                    contentAlignment = Alignment.Center,
                 ) {
+                    AnimatedVisibility(visible = loading) {
+                        CircularProgressIndicator()
+                    }
+
                     val dialog = dialogHelper(
                         state = domains,
                         onClose = { confirmed ->
                             scope.launch(Dispatchers.IO) {
                                 if (confirmed == true) {
-                                    repository.insert(domains.map {
-                                        PreferredApp(
-                                            host = it,
-                                            packageName = callingPackage,
-                                            component = callingComponent.flattenToString(),
-                                            alwaysPreferred = true,
+                                    loading = true
+
+                                    val preferred = mutableListOf<PreferredApp>()
+                                    val history = mutableListOf<AppSelectionHistory>()
+
+                                    domains.forEach { domain ->
+                                        preferred.add(
+                                            PreferredApp(
+                                                host = domain,
+                                                packageName = callingPackage,
+                                                component = callingComponent.flattenToString(),
+                                                alwaysPreferred = true,
+                                            )
                                         )
-                                    })
+
+                                        history.add(
+                                            AppSelectionHistory(
+                                                host = domain,
+                                                packageName = callingPackage,
+                                                lastUsed = System.currentTimeMillis(),
+                                            )
+                                        )
+                                    }
+
+                                    preferredAppRepository.insert(preferred)
+                                    appSelectionHistoryRepository.insert(history)
+
+                                    loading = false
                                 }
 
                                 finish()

--- a/app/src/main/java/fe/linksheet/module/repository/AppSelectionHistoryRepository.kt
+++ b/app/src/main/java/fe/linksheet/module/repository/AppSelectionHistoryRepository.kt
@@ -4,12 +4,12 @@ import android.net.Uri
 import fe.linksheet.module.database.dao.AppSelectionHistoryDao
 import fe.linksheet.module.database.entity.AppSelectionHistory
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
 
 class AppSelectionHistoryRepository(private val dao: AppSelectionHistoryDao) {
     suspend fun insert(appSelectionHistory: AppSelectionHistory) = dao.insert(appSelectionHistory)
+    suspend fun insert(appSelectionHistories: List<AppSelectionHistory>) = dao.insert(appSelectionHistories)
 
     suspend fun getLastUsedForHostGroupedByPackage(uri: Uri?) = uri?.host?.let { host ->
         dao.getLastUsedForHostGroupedByPackage(host).map { appSelections ->

--- a/versions.properties
+++ b/versions.properties
@@ -47,4 +47,4 @@ version.junit.junit=4.13.2
 version.koin=3.4.3
 version.org.jsoup..jsoup=1.16.1
 version.org.lsposed.hiddenapibypass..hiddenapibypass=4.3
-version.com.github.1fexd..LinkSheetInterConnect=1.0.6
+version.com.github.1fexd..LinkSheetInterConnect=1.1.0


### PR DESCRIPTION
When selecting apps through LinkSheet, it saves the component as the first returned Activity in the app, not necessarily the component that actually has the domain filter. So when BottomSheetGrouper checks `isLastChosenPosition()` it'll be false in some cases (with Fediverse Redirect, `lastChosenComponent` will be MainActivity, but the resolved component will be RedirectActivity).

This PR adds a second check to get all possible filtered pairs in the same package. If there's only one, it takes that as the last selected pair, even if the component names don't match.

It also inserts the domains into the app selection history DB to match the in-app behavior of selecting domains.