### PR TITLE
feat: Add `selectDomainsWithCallback()` API

### DIFF
--- a/app/src/main/java/fe/linksheet/InterconnectService.kt
+++ b/app/src/main/java/fe/linksheet/InterconnectService.kt
@@ -11,6 +11,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.graphics.drawable.IconCompat
 import fe.linksheet.activity.SelectDomainsConfirmationActivity
+import fe.linksheet.interconnect.IDomainSelectionResultCallback
 import fe.linksheet.interconnect.ILinkSheetService
 import fe.linksheet.interconnect.ISelectedDomainsCallback
 import fe.linksheet.interconnect.StringParceledListSlice
@@ -77,6 +78,20 @@ class InterconnectService : Service(), CoroutineScope by MainScope() {
 
                 SelectDomainsConfirmationActivity.start(
                     this@InterconnectService, packageName, componentName, domains,
+                )
+            }
+
+            override fun selectDomainsWithCallback(
+                packageName: String,
+                domains: StringParceledListSlice,
+                componentName: ComponentName,
+                callback: IDomainSelectionResultCallback,
+            ) {
+                verifyCaller(packageName)
+
+                SelectDomainsConfirmationActivity.start(
+                    this@InterconnectService, packageName, componentName, domains,
+                    callback,
                 )
             }
         }

--- a/versions.properties
+++ b/versions.properties
@@ -47,4 +47,4 @@ version.junit.junit=4.13.2
 version.koin=3.4.3
 version.org.jsoup..jsoup=1.16.1
 version.org.lsposed.hiddenapibypass..hiddenapibypass=4.3
-version.com.github.1fexd..LinkSheetInterConnect=1.1.0
+version.com.github.1fexd..LinkSheetInterConnect=2.2.0


### PR DESCRIPTION
Implements a new API in the interconnect library allowing clients to receive a status directly.

A possible future feature: let the user deselect requested domains before confirming. The interconnect API supports this third state, but it's not implemented with this PR.