### PR TITLE
feat: Don't persist chosen app if it was the only option

### DIFF
--- a/app/src/main/java/fe/linksheet/activity/BottomSheetActivity.kt
+++ b/app/src/main/java/fe/linksheet/activity/BottomSheetActivity.kt
@@ -138,7 +138,8 @@ class BottomSheetActivity : ComponentActivity() {
                 launchApp(
                     completed,
                     completed.app,
-                    always = completed.isRegularPreferredApp
+                    always = completed.isRegularPreferredApp,
+                    persist = false,
                 )
             }
         }
@@ -993,10 +994,12 @@ class BottomSheetActivity : ComponentActivity() {
         result: BottomSheetResult.BottomSheetSuccessResult,
         info: DisplayActivityInfo,
         always: Boolean = false,
-        privateBrowsingBrowser: PrivateBrowsingBrowser? = null
+        privateBrowsingBrowser: PrivateBrowsingBrowser? = null,
+        persist: Boolean = true,
     ) {
         val deferred = bottomSheetViewModel.launchAppAsync(
-            info, result.intent, always, privateBrowsingBrowser
+            info, result.intent, always, privateBrowsingBrowser,
+            persist,
         )
 
         deferred.invokeOnCompletion {

--- a/app/src/main/java/fe/linksheet/module/viewmodel/BottomSheetViewModel.kt
+++ b/app/src/main/java/fe/linksheet/module/viewmodel/BottomSheetViewModel.kt
@@ -147,13 +147,14 @@ class BottomSheetViewModel(
         info: DisplayActivityInfo,
         intent: Intent,
         always: Boolean = false,
-        privateBrowsingBrowser: PrivateBrowsingBrowser? = null
+        privateBrowsingBrowser: PrivateBrowsingBrowser? = null,
+        persist: Boolean = true,
     ) = ioAsync {
         val newIntent = info.intentFrom(intent).let {
             privateBrowsingBrowser?.requestPrivateBrowsing(it) ?: it
         }
 
-        if (privateBrowsingBrowser == null) {
+        if (persist && privateBrowsingBrowser == null) {
             persistSelectedIntent(newIntent, always)
         }
 


### PR DESCRIPTION
This works around an issue where an app launching using a selector to force a link to open in the browser (e.g., Fediverse Redirect opening media files in the browser) will have its preferred status automatically overridden from that launch.