### PR TITLE
feat: Forward Intent referrer as an extra to the target app

### DIFF
--- a/app/src/main/java/fe/linksheet/activity/BottomSheetActivity.kt
+++ b/app/src/main/java/fe/linksheet/activity/BottomSheetActivity.kt
@@ -999,7 +999,7 @@ class BottomSheetActivity : ComponentActivity() {
     ) {
         val deferred = bottomSheetViewModel.launchAppAsync(
             info, result.intent, always, privateBrowsingBrowser,
-            persist,
+            persist, referrer,
         )
 
         deferred.invokeOnCompletion {

--- a/app/src/main/java/fe/linksheet/activity/BottomSheetActivity.kt
+++ b/app/src/main/java/fe/linksheet/activity/BottomSheetActivity.kt
@@ -138,7 +138,8 @@ class BottomSheetActivity : ComponentActivity() {
                 launchApp(
                     completed,
                     completed.app,
-                    always = completed.isRegularPreferredApp
+                    always = completed.isRegularPreferredApp,
+                    persist = false,
                 )
             }
         }
@@ -993,10 +994,12 @@ class BottomSheetActivity : ComponentActivity() {
         result: BottomSheetResult.BottomSheetSuccessResult,
         info: DisplayActivityInfo,
         always: Boolean = false,
-        privateBrowsingBrowser: PrivateBrowsingBrowser? = null
+        privateBrowsingBrowser: PrivateBrowsingBrowser? = null,
+        persist: Boolean = true,
     ) {
         val deferred = bottomSheetViewModel.launchAppAsync(
-            info, result.intent, always, privateBrowsingBrowser
+            info, result.intent, always, privateBrowsingBrowser,
+            persist,
         )
 
         deferred.invokeOnCompletion {

--- a/app/src/main/java/fe/linksheet/module/viewmodel/BottomSheetViewModel.kt
+++ b/app/src/main/java/fe/linksheet/module/viewmodel/BottomSheetViewModel.kt
@@ -21,6 +21,7 @@ import fe.linksheet.R
 import fe.linksheet.activity.MainActivity
 import fe.linksheet.extension.android.ioAsync
 import fe.linksheet.extension.android.startActivityWithConfirmation
+import fe.linksheet.interconnect.LinkSheetConnector
 import fe.linksheet.module.database.entity.AppSelectionHistory
 import fe.linksheet.module.database.entity.PreferredApp
 import fe.linksheet.module.downloader.Downloader
@@ -149,10 +150,13 @@ class BottomSheetViewModel(
         always: Boolean = false,
         privateBrowsingBrowser: PrivateBrowsingBrowser? = null,
         persist: Boolean = true,
+        referrer: Uri? = null,
     ) = ioAsync {
         val newIntent = info.intentFrom(intent).let {
             privateBrowsingBrowser?.requestPrivateBrowsing(it) ?: it
         }
+
+        newIntent.putExtra(LinkSheetConnector.EXTRA_REFERRER, referrer)
 
         if (persist && privateBrowsingBrowser == null) {
             persistSelectedIntent(newIntent, always)

--- a/app/src/main/java/fe/linksheet/module/viewmodel/BottomSheetViewModel.kt
+++ b/app/src/main/java/fe/linksheet/module/viewmodel/BottomSheetViewModel.kt
@@ -147,13 +147,14 @@ class BottomSheetViewModel(
         info: DisplayActivityInfo,
         intent: Intent,
         always: Boolean = false,
-        privateBrowsingBrowser: PrivateBrowsingBrowser? = null
+        privateBrowsingBrowser: PrivateBrowsingBrowser? = null,
+        persist: Boolean = true,
     ) = ioAsync {
         val newIntent = info.intentFrom(intent).let {
             privateBrowsingBrowser?.requestPrivateBrowsing(it) ?: it
         }
 
-        if (privateBrowsingBrowser == null) {
+        if (persist && privateBrowsingBrowser == null) {
             persistSelectedIntent(newIntent, always)
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ gradle = { id = "gradle", version = "8.1.0" }
 
 kotlin = "1.9.0"
 koin = "3.4.3"
-linkSheetInterConnect = "2.2.0"
+linkSheetInterConnect = "2.3.1"
 
 [libraries]
 

--- a/versions.properties
+++ b/versions.properties
@@ -88,4 +88,4 @@ version.junit.junit=4.13.2
 version.org.jsoup..jsoup=1.16.1
 
 version.org.lsposed.hiddenapibypass..hiddenapibypass=4.3
-version.com.github.1fexd..LinkSheetInterConnect=2.2.0
+version.com.github.1fexd..LinkSheetInterConnect=2.3.1


### PR DESCRIPTION
Depends on https://github.com/1fexd/LinkSheet/pull/187 because I forgot to switch branches.

Adds an Intent extra value to forward the original Intent referrer to the target app when launching it, so apps integrated with LinkSheet can retrieve it.

Supposedly it's possible to spoof `Activity#getReferrer()`, which might be a better and more transparent solution. I'll look into it.