### PR TITLE
feat: Set platform EXTRA_REFERRER in launch intent.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,6 @@ import de.fayard.refreshVersions.core.versionFor
 import net.nemerosa.versioning.ReleaseInfo
 import net.nemerosa.versioning.SCMInfo
 import groovy.lang.Closure
-import net.nemerosa.versioning.VersionInfo
 import net.nemerosa.versioning.VersioningExtension
 
 plugins {
@@ -44,7 +43,7 @@ android {
         targetSdk = 34
 
         val now = System.currentTimeMillis()
-        val versionInfo = providers.exec { versioning.info }.result.get() as VersionInfo
+        val versionInfo = providers.provider { versioning.info }.get()
 
         versionCode = versionInfo.tag?.let {
             versionInfo.versionNumber.versionCode

--- a/app/src/main/java/fe/linksheet/activity/BottomSheetActivity.kt
+++ b/app/src/main/java/fe/linksheet/activity/BottomSheetActivity.kt
@@ -71,6 +71,7 @@ import fe.linksheet.extension.android.startPackageInfoActivity
 import fe.linksheet.extension.compose.currentActivity
 import fe.linksheet.extension.compose.nullClickable
 import fe.linksheet.extension.compose.runIf
+import fe.linksheet.interconnect.LinkSheetConnector
 import fe.linksheet.module.database.entity.LibRedirectDefault
 import fe.linksheet.module.downloader.Downloader
 import fe.linksheet.module.resolver.LibRedirectResolver
@@ -999,11 +1000,24 @@ class BottomSheetActivity : ComponentActivity() {
     ) {
         val deferred = bottomSheetViewModel.launchAppAsync(
             info, result.intent, always, privateBrowsingBrowser,
-            persist, referrer,
+            persist,
         )
 
         deferred.invokeOnCompletion {
-            startActivity(deferred.getCompleted())
+            val showAsReferrer = bottomSheetViewModel.showAsReferrer.value
+            val intent = deferred.getCompleted()
+
+            intent.putExtra(
+                LinkSheetConnector.EXTRA_REFERRER,
+                if (showAsReferrer) Uri.parse("android-app://${packageName}") else referrer,
+            )
+
+            if (!showAsReferrer) {
+                intent.putExtra(Intent.EXTRA_REFERRER, referrer)
+            }
+
+            startActivity(intent)
+
             finish()
         }
     }

--- a/app/src/main/java/fe/linksheet/composable/settings/privacy/PrivacySettingsRoute.kt
+++ b/app/src/main/java/fe/linksheet/composable/settings/privacy/PrivacySettingsRoute.kt
@@ -29,10 +29,10 @@ fun PrivacySettingsRoute(
         ) {
             item(key = "include_referrer") {
                 SwitchRow(
-                    state = viewModel.includeReferrer,
+                    state = viewModel.showAsReferrer,
                     viewModel = viewModel,
-                    headline = stringResource(id = R.string.include_referrer),
-                    subtitle = stringResource(id = R.string.include_referrer_explainer)
+                    headline = stringResource(id = R.string.show_linksheet_referrer),
+                    subtitle = stringResource(id = R.string.show_linksheet_referrer_explainer)
                 )
             }
         }

--- a/app/src/main/java/fe/linksheet/module/preference/AppPreferences.kt
+++ b/app/src/main/java/fe/linksheet/module/preference/AppPreferences.kt
@@ -71,7 +71,7 @@ object AppPreferences : Preferences() {
     )
     val useTimeMs = longPreference("use_time", 0)
 
-    val includeReferrer =  booleanPreference("include_referer", true)
+    val showLinkSheetAsReferrer =  booleanPreference("show_as_referrer", false)
 
     val logKey = stringPreference("log_key") {
         CryptoUtil.getRandomBytes(loggerHmac.keySize).toHexString()

--- a/app/src/main/java/fe/linksheet/module/viewmodel/BottomSheetViewModel.kt
+++ b/app/src/main/java/fe/linksheet/module/viewmodel/BottomSheetViewModel.kt
@@ -76,7 +76,7 @@ class BottomSheetViewModel(
     )
 
     val enableAmp2Html = preferenceRepository.getBooleanState(AppPreferences.enableAmp2Html)
-    val includeReferrer = preferenceRepository.getBooleanState(AppPreferences.includeReferrer)
+    val showAsReferrer = preferenceRepository.getBooleanState(AppPreferences.showLinkSheetAsReferrer)
 
     val clipboardManager = context.getSystemService<ClipboardManager>()!!
     val downloadManager = context.getSystemService<DownloadManager>()!!
@@ -151,14 +151,9 @@ class BottomSheetViewModel(
         always: Boolean = false,
         privateBrowsingBrowser: PrivateBrowsingBrowser? = null,
         persist: Boolean = true,
-        referrer: Uri? = null,
     ) = ioAsync {
         val newIntent = info.intentFrom(intent).let {
             privateBrowsingBrowser?.requestPrivateBrowsing(it) ?: it
-        }
-
-        if (includeReferrer.value) {
-            newIntent.putExtra(LinkSheetConnector.EXTRA_REFERRER, referrer)
         }
 
         if (persist && privateBrowsingBrowser == null) {

--- a/app/src/main/java/fe/linksheet/module/viewmodel/PrivacySettingsViewModel.kt
+++ b/app/src/main/java/fe/linksheet/module/viewmodel/PrivacySettingsViewModel.kt
@@ -11,5 +11,5 @@ class PrivacySettingsViewModel(
     val context: Application,
     preferenceRepository: AppPreferenceRepository
 ) : BaseViewModel(preferenceRepository) {
-    var includeReferrer = preferenceRepository.getBooleanState(AppPreferences.includeReferrer)
+    var showAsReferrer = preferenceRepository.getBooleanState(AppPreferences.showLinkSheetAsReferrer)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -293,7 +293,7 @@
     <string name="github_workflow_run_id">Build workflow:</string>
     <string name="linksheet_version_info_header">LinkSheet Version Information:</string>
     <string name="privacy">Privacy</string>
-    <string name="include_referrer">Include referrer</string>
-    <string name="include_referrer_explainer">When this setting is enabled, LinkSheet will allow the app that is launched to know LinkSheet was used. Even if this setting is enabled, launched apps will explicitly have to check if LinkSheet was used.</string>
+    <string name="show_linksheet_referrer">Show LinkSheet referrer</string>
+    <string name="show_linksheet_referrer_explainer">When an app is launched, it can check to see which app launched, or \"referred\" it. By default, when LinkSheet launches an app, it hides itself, saying that the app that launched LinkSheet is the one that launched the target. Enable this to reinsert LinkSheet as the referrer for apps it opens.</string>
     <string name="privacy_settings_explainer">Settings like referrer inclusion</string>
 </resources>


### PR DESCRIPTION
It turns out it isn't possible to override `Activity.mReferrer`, but using `putExtra(Intent.EXTRA_REFERRER, referrer)` should be enough for most cases.

Also contains:
- fix: Fix build.
- fix: Correct wording for referrer toggle.